### PR TITLE
Improve setup instructions and add auto-install

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+# Sistema Forense de Atribución de Autoría
+
+Este proyecto reúne tres módulos de análisis de texto en español:
+
+- **N-gramas**: perfiles de carácter y palabra.
+- **Análisis sintáctico**: distribución de etiquetas gramaticales y dependencias.
+- **Complejidad léxica**: métricas de diversidad y sofisticación del vocabulario.
+
+El script `full_analysis.py` ejecuta los tres módulos de forma consecutiva y reúne los resultados en un solo directorio.
+
+## Organización de carpetas
+
+1. **Textos conocidos** (`--known`)
+   - Debe ser un directorio que contenga **subdirectorios por autor**. Cada subdirectorio incluye los archivos de texto (`.txt`, `.md` o `.text`) que pertenecen a dicho autor.
+   - Ejemplo:
+     ```
+     conocidos/
+       autor1/
+         a1.txt
+         a2.txt
+       autor2/
+         b1.txt
+     ```
+
+2. **Textos dubitados** (`--query`)
+   - Directorio con archivos de texto individuales. No requiere subdirectorios.
+   - Ejemplo:
+     ```
+     dubitados/
+       q1.txt
+       q2.txt
+     ```
+
+3. **Salida** (`--out`)
+   - Directorio donde se guardarán los resultados generados por el script. Se crearán subcarpetas para cada tipo de análisis.
+
+## Ejecución rápida
+
+1. Asegúrate de tener Python instalado.
+2. Ejecuta el script principal desde la línea de comandos:
+
+   ```bash
+   python full_analysis.py --known ruta/conocidos --query ruta/dubitados --out salida
+   ```
+
+   Al iniciarse, `full_analysis.py` comprobará e instalará automáticamente los paquetes indicados en `requirements.txt` si alguno falta.
+
+Los resultados incluirán archivos CSV con perfiles, gráficas PNG y un archivo `full_summary.txt` con las rutas de todos los artefactos generados.

--- a/full_analysis.py
+++ b/full_analysis.py
@@ -4,6 +4,40 @@
 import argparse
 from pathlib import Path
 import importlib.util
+import subprocess
+import sys
+
+
+def install_requirements() -> None:
+    """Instala los paquetes listados en requirements.txt si faltan."""
+    req_file = Path(__file__).with_name("requirements.txt")
+    if not req_file.exists():
+        return
+
+    try:
+        import pkg_resources
+
+        with open(req_file, "r", encoding="utf-8") as f:
+            packages = [line.strip() for line in f if line.strip() and not line.startswith("#")]
+
+        missing = []
+        for pkg in packages:
+            try:
+                pkg_resources.require(pkg)
+            except (pkg_resources.DistributionNotFound, pkg_resources.VersionConflict):
+                missing.append(pkg)
+
+        if missing:
+            print(f"Instalando dependencias: {', '.join(missing)}")
+            subprocess.check_call([sys.executable, "-m", "pip", "install", *missing])
+    except Exception as e:  # pragma: no cover - solo se usa en ejecución directa
+        print(f"Advertencia: no se pudo instalar dependencias automáticamente: {e}")
+
+
+
+
+# Instalar dependencias antes de cargar los módulos
+install_requirements()
 
 # Cargar módulos con nombres que contienen espacios
 


### PR DESCRIPTION
## Summary
- add auto-install of requirements when running `full_analysis.py`
- document directory structure and usage in new README

## Testing
- `python -m py_compile full_analysis.py`
- `python -m py_compile N-gramas.py analisis\ sintactico.py complejidad\ lexica.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685e5545a548832c8773f18a510bf5da