### PR TITLE
Fix disable_pipes call

### DIFF
--- a/analisis sintactico.py
+++ b/analisis sintactico.py
@@ -64,7 +64,9 @@ class SyntaxForensics:
         try:
             self.nlp = spacy.load(self.model_name)
             # Optimización: desactivar componentes innecesarios
-            self.nlp.disable_pipes(['ner', 'textcat'] if 'textcat' in self.nlp.pipe_names else ['ner'])
+            pipes_to_disable = [p for p in ('ner', 'textcat') if p in self.nlp.pipe_names]
+            if pipes_to_disable:
+                self.nlp.disable_pipes(*pipes_to_disable)
             logger.info(f"Modelo {self.model_name} cargado exitosamente")
         except OSError:
             logger.error(f"Error: Modelo {self.model_name} no encontrado")


### PR DESCRIPTION
## Summary
- update `_load_model` to conditionally disable `ner` and `textcat` pipes using separate arguments

## Testing
- `python3 -m py_compile "analisis sintactico.py"`

------
https://chatgpt.com/codex/tasks/task_e_687029d1d324832c97cb46ef47acbf17