### PR TITLE
Harmonize input formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Este proyecto reúne tres módulos de análisis de texto en español:
 
 El script `full_analysis.py` ejecuta los tres módulos de forma consecutiva y reúne los resultados en un solo directorio.
 
+Los cargadores de texto aceptan archivos con extensiones `.txt`, `.md` y `.text`.
+
 ## Organización de carpetas
 
 1. **Textos conocidos** (`--known`)
@@ -23,7 +25,7 @@ El script `full_analysis.py` ejecuta los tres módulos de forma consecutiva y re
      ```
 
 2. **Textos dubitados** (`--query`)
-   - Directorio con archivos de texto individuales. No requiere subdirectorios.
+   - Directorio con archivos de texto individuales (`.txt`, `.md` o `.text`). No requiere subdirectorios.
    - Ejemplo:
      ```
      dubitados/

--- a/analisis sintactico.py
+++ b/analisis sintactico.py
@@ -517,15 +517,18 @@ def load_texts_from_directory(directory: Path, combine_subdirs: bool = False) ->
                 texts[sub.name] = "\n".join(sub_texts.values())
         return texts
 
-    for file_path in directory.glob("*.txt"):
-        try:
-            with open(file_path, 'r', encoding='utf-8') as f:
-                content = f.read().strip()
-                if content:
-                    texts[file_path.stem] = content
-                    logger.info(f"Cargado: {file_path.name} ({len(content)} caracteres)")
-        except Exception as e:
-            logger.warning(f"Error cargando {file_path}: {e}")
+    extensions = [".txt", ".md", ".text"]
+
+    for file_path in directory.iterdir():
+        if file_path.is_file() and file_path.suffix.lower() in extensions:
+            try:
+                with open(file_path, 'r', encoding='utf-8') as f:
+                    content = f.read().strip()
+                    if content:
+                        texts[file_path.stem] = content
+                        logger.info(f"Cargado: {file_path.name} ({len(content)} caracteres)")
+            except Exception as e:
+                logger.warning(f"Error cargando {file_path}: {e}")
 
     return texts
 

--- a/complejidad lexica.py
+++ b/complejidad lexica.py
@@ -504,14 +504,17 @@ def load_texts_from_directory(directory: Path, combine_subdirs: bool = False) ->
                 texts[sub.name] = "\n".join(sub_texts.values())
         return texts
 
-    for file_path in directory.glob("*.txt"):
-        try:
-            with open(file_path, "r", encoding="utf-8") as f:
-                content = f.read().strip()
-                if content:
-                    texts[file_path.stem] = content
-        except Exception:
-            pass
+    extensions = [".txt", ".md", ".text"]
+
+    for file_path in directory.iterdir():
+        if file_path.is_file() and file_path.suffix.lower() in extensions:
+            try:
+                with open(file_path, "r", encoding="utf-8") as f:
+                    content = f.read().strip()
+                    if content:
+                        texts[file_path.stem] = content
+            except Exception:
+                pass
 
     return texts
 


### PR DESCRIPTION
## Summary
- allow `.md` and `.text` files in `load_texts_from_directory`
- note supported formats in README

## Testing
- `python -m py_compile complejidad\ lexica.py analisis\ sintactico.py N-gramas.py full_analysis.py`

------
https://chatgpt.com/codex/tasks/task_e_68702c29ff98832cb039fe63c440b40e