### PR TITLE
Fix subdir combination for nested folders

### DIFF
--- a/N-gramas.py
+++ b/N-gramas.py
@@ -566,7 +566,7 @@ def load_texts_from_directory(directory: Path, combine_subdirs: bool = False) ->
     # Cuando se solicite combinar subdirectorios y existan carpetas internas
     if combine_subdirs and subdirs:
         for sub in subdirs:
-            sub_texts = load_texts_from_directory(sub)
+            sub_texts = load_texts_from_directory(sub, combine_subdirs=combine_subdirs)
             if sub_texts:
                 texts[sub.name] = "\n".join(sub_texts.values())
         return texts

--- a/analisis sintactico.py
+++ b/analisis sintactico.py
@@ -553,7 +553,7 @@ def load_texts_from_directory(directory: Path, combine_subdirs: bool = False) ->
     subdirs = [d for d in directory.iterdir() if d.is_dir()]
     if combine_subdirs and subdirs:
         for sub in subdirs:
-            sub_texts = load_texts_from_directory(sub)
+            sub_texts = load_texts_from_directory(sub, combine_subdirs=combine_subdirs)
             if sub_texts:
                 texts[sub.name] = "\n".join(sub_texts.values())
         return texts

--- a/complejidad lexica.py
+++ b/complejidad lexica.py
@@ -538,7 +538,7 @@ def load_texts_from_directory(directory: Path, combine_subdirs: bool = False) ->
     subdirs = [d for d in directory.iterdir() if d.is_dir()]
     if combine_subdirs and subdirs:
         for sub in subdirs:
-            sub_texts = load_texts_from_directory(sub)
+            sub_texts = load_texts_from_directory(sub, combine_subdirs=combine_subdirs)
             if sub_texts:
                 texts[sub.name] = "\n".join(sub_texts.values())
         return texts


### PR DESCRIPTION
## Summary
- propagate `combine_subdirs` flag in recursive `load_texts_from_directory` calls

## Testing
- `python -m py_compile N-gramas.py 'analisis sintactico.py' 'complejidad lexica.py' full_analysis.py`

------
https://chatgpt.com/codex/tasks/task_e_687075ab6818832cbd3bde826c48da0b