### PR TITLE
Fix _compare_single on empty profiles

### DIFF
--- a/N-gramas.py
+++ b/N-gramas.py
@@ -287,6 +287,13 @@ class ForensicAnalyzer:
 
         results = {}
 
+        if not profiles_b:
+            logger.warning("profiles_b está vacío. Devolviendo DataFrames vacíos")
+            empty_index = list(profiles_a.keys())
+            for m in metrics:
+                results[m] = pd.DataFrame(index=empty_index)
+            return results
+
         if "cosine" in metrics:
             logger.info("Calculando similitud coseno TF-IDF...")
             results["cosine"] = self.cosine_tfidf_similarity(profiles_a, profiles_b)


### PR DESCRIPTION
## Summary
- handle empty profiles_b in `_compare_single`

## Testing
- `python -m py_compile N-gramas.py full_analysis.py 'analisis sintactico.py' 'complejidad lexica.py'`


------
https://chatgpt.com/codex/tasks/task_e_6870dfcf8278832c8f8db9428b0e5bb9