### PR TITLE
Fix IDF division by zero issue

### DIFF
--- a/N-gramas.py
+++ b/N-gramas.py
@@ -168,7 +168,7 @@ class ForensicAnalyzer:
             # IDF: log(N / df)
             df = (matrix > 0).sum(axis=0)
             n_docs = matrix.shape[0]
-            idf = np.log(n_docs / (df + 1))
+            idf = np.log(n_docs / (df + 1e-10))  # 1e-10 para evitar division por cero
             
             return tf * idf
         


### PR DESCRIPTION
## Summary
- avoid division by zero when computing IDF in `N-gramas.py`

## Testing
- `python -m py_compile N-gramas.py`

------
https://chatgpt.com/codex/tasks/task_e_687078c438ec832ca6aaa67591e89cac